### PR TITLE
Parser doesn't return queries in extra vector

### DIFF
--- a/src/test/compassus/tests.cljc
+++ b/src/test/compassus/tests.cljc
@@ -301,20 +301,20 @@
         r (c/get-reconciler app)]
     (is (= (om/gather-sends (#'om/to-env r)
              (om/get-query (c/root-class app)) [:some-remote])
-           {:some-remote [[{:index (om/get-query Home)}]]}))
+           {:some-remote [{:index (om/get-query Home)}]}))
     (c/mount! app nil)
     (is (= (dissoc @(c/get-reconciler app) ::c/route) (select-keys init-state (om/get-query Home))))
     (is (= (om/gather-sends (#'om/to-env r)
              '[(fire/missiles! {:how-many 42})] [:some-remote])
-           {:some-remote ['[(fire/missiles! {:how-many 42})]]}))
+           {:some-remote '[(fire/missiles! {:how-many 42})]}))
     (c/set-route! app :about)
     (is (= (om/gather-sends (#'om/to-env r)
              (om/get-query (c/root-class app)) [:some-remote])
-           {:some-remote [[{:about (om/get-query About)}]]}))
+           {:some-remote [{:about (om/get-query About)}]}))
     (c/set-route! app :other)
     (is (= (om/gather-sends (#'om/to-env r)
              (om/get-query (c/root-class app)) [:some-remote])
-           {:some-remote [[{:other [:changed/key :updated/ast]}]]}))
+           {:some-remote [{:other [:changed/key :updated/ast]}]}))
     (om/transact! r '[(fire/missiles! {:how-many 3})])
     (test-async
       (go
@@ -452,7 +452,7 @@
          r (c/get-reconciler app)]
     (is (= (om/gather-sends (#'om/to-env r)
              '[(do/stuff! {:when :now})] [:remote])
-           {:remote ['[(do/stuff! {:when :later})]]}))
+           {:remote '[(do/stuff! {:when :later})]}))
     (is (empty? (om/gather-sends (#'om/to-env r)
                   '[(other/stuff!)] [:remote])))))
 
@@ -529,10 +529,10 @@
     (is (= (:app/title reread-ret2) "Some App"))
     (is (= (om/gather-sends (#'om/to-env r)
              '[(some/action!) :remote/key] [:remote])
-           {:remote [[:remote/key]]}))
+           {:remote [:remote/key]}))
     (is (= (om/gather-sends (#'om/to-env r)
              '[(some/action!) {:remote/key [:foo :bar]}] [:remote])
-           {:remote [[{:remote/key [:foo :bar]}]]}))))
+           {:remote [{:remote/key [:foo :bar]}]}))))
 
 (defui Person
   static om/Ident
@@ -825,7 +825,7 @@
              {::c/mixin-data [{:foo [:bar :baz]}]}]))
       (is (= (om/gather-sends (#'om/to-env r)
                (om/get-query root) [:some-remote])
-             {:some-remote [[{:foo [:bar :baz]}]]}))))
+             {:some-remote [{:foo [:bar :baz]}]}))))
   (testing "wrapper updates"
     (reset! update-atom {})
     (let [#?@(:cljs [shallow-renderer (.createRenderer test-utils)])
@@ -962,18 +962,18 @@
         r (c/get-reconciler app)]
     (is (= (om/gather-sends (#'om/to-env r)
              (om/get-query (c/root-class app)) [:some-remote])
-           {:some-remote [(om/get-query Home)]}))
+           {:some-remote (om/get-query Home)}))
     (c/mount! app nil)
     (is (= (dissoc @(c/get-reconciler app) ::c/route) {:home/title :title
                                                        :home/content :content}))
     (c/set-route! app :about)
     (is (= (om/gather-sends (#'om/to-env r)
              (om/get-query (c/root-class app)) [:some-remote])
-           {:some-remote [(om/get-query About)]}))
+           {:some-remote (om/get-query About)}))
     (c/set-route! app :other)
     (is (= (om/gather-sends (#'om/to-env r)
              (om/get-query (c/root-class app)) [:some-remote])
-           {:some-remote [[:changed/key :foo :bar]]}))))
+           {:some-remote [:changed/key :foo :bar]}))))
 
 (defn compassus-16-read
   [{:keys [state query target ast] :as env} k _]


### PR DESCRIPTION
Rather than return the query wrapped in an extra vector and deal with that by wrapping the `send` function, this returns a valid query from the parser itself.