### PR TITLE
COMPASSSUS-29: use current route's query in the callback to `send`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [master](https://github.com/anmonteiro/compassus/compare/1.0.0-alpha3...HEAD) (unreleased)
 
+### Changes
+
+- Use current route's query by default if `send` doesn't pass one in the callback
+([#29](https://github.com/compassus/compassus/issues/29)).
+
 ## [1.0.0-alpha3](https://github.com/anmonteiro/compassus/compare/1.0.0-alpha2...1.0.0-alpha3) (2017-05-14)
 
 ### Changes

--- a/src/test/compassus/tests.cljc
+++ b/src/test/compassus/tests.cljc
@@ -4,7 +4,7 @@
                        [cljsjs.react.dom]
                        [goog.object :as gobj]]
                 :clj [[om.dom :as dom]])
-            [clojure.core.async :refer [<! close! chan take! #?@(:clj [go <!!])]]
+            [clojure.core.async :refer [<! close! put! chan take! #?@(:clj [go <!!])]]
             [clojure.test :refer [deftest testing is are use-fixtures #?(:cljs async)]]
             [om.next :as om :refer [defui ui]]
             [om.next.impl.parser :as parser]
@@ -972,7 +972,6 @@
 
 (deftest test-flat-remote-integration
   (let [remote-parser (om/parser {:read remote-flat-read})
-        c (chan)
         app (c/application
               {:routes {:index Home
                         :about About
@@ -984,8 +983,7 @@
                                                  :route-dispatch false})
                               :remotes [:some-remote]
                               :send (fn [{:keys [some-remote]} cb]
-                                      (cb (remote-parser {} some-remote))
-                                      (close! c))})})
+                                      (cb (remote-parser {} some-remote)))})})
         r (c/get-reconciler app)]
     (is (= (om/gather-sends (#'om/to-env r)
              (om/get-query (c/root-class app)) [:some-remote])
@@ -1101,8 +1099,7 @@
 
 (defn compassus-29-local-read
   [{:keys [state query]} k _]
-  (let [st @state]
-    {:remote true}))
+  {:remote true})
 
 (defn compassus-29-remote-read
   [_ k _]
@@ -1142,4 +1139,37 @@
         (is (contains? @r :posts/list))
         (is (contains? @r :post/by-id))
         (is (= (keys (:post/by-id @r)) [0 1]))
-        (is (= (:posts/list @r) [[:post/by-id 0] [:post/by-id 1]]))))))
+        (is (= (:posts/list @r) [[:post/by-id 0] [:post/by-id 1]])))))
+  (testing "works after remote updates"
+    (let [remote-parser (om/parser {:read compassus-29-remote-read
+                                    :mutate (fn [_ _ _]
+                                              {:action (constantly nil)})})
+          ch (chan)
+          #?@(:cljs [shallow-renderer (.createRenderer test-utils)])
+          app (c/application {:routes {:posts PostList}
+                              :reconciler
+                              (om/reconciler
+                                {:state {}
+                                 :merge c/compassus-merge
+                                 :root-unmount (fn [_])
+                                 #?@(:cljs [:root-render (fn [c target]
+                                                           (.render shallow-renderer c))])
+                                 :send (fn [{:keys [remote]} cb]
+                                         (cb (remote-parser {} remote))
+                                         (close! ch))
+                                 :parser (c/parser {:read compassus-29-local-read
+                                                    :mutate (fn [_ _ _]
+                                                              {:remote true})})})})
+          r (c/get-reconciler app)
+          c (c/mount! app :target)]
+      #?(:clj (p/-render c))
+      (reset! (-> r :config :state) (select-keys @r [::c/route]))
+      (swap! (:state r) assoc :remove (fn [] (println "why a i removing? 2222" )) )
+      (let [#?@(:cljs [st js/setTimeout])]
+        #?(:cljs (set! js/setTimeout (fn [f _] (f))))
+        (om/transact! r (into '[(some/mutation!)] [{::c/route-data {:posts (om/get-query PostList)}}]))
+        (is (contains? @r :posts/list))
+        (is (contains? @r :post/by-id))
+        (is (= (keys (:post/by-id @r)) [0 1]))
+        (is (= (:posts/list @r) [[:post/by-id 0] [:post/by-id 1]]))
+        #?(:cljs (set! js/setTimeout st))))))


### PR DESCRIPTION
fixes #29